### PR TITLE
Fix bug clearing task data on API failure

### DIFF
--- a/func.py
+++ b/func.py
@@ -398,17 +398,17 @@ async def add_task(update: Update, context: ContextTypes.DEFAULT_TYPE, query=Fal
         json=task_data,
         headers={"Authorization": f"Bearer {api_key}"}
     )
+
     if response.status_code in (200, 204):
         message = "Задача успешно добавлена!\nТеперь Вы можете добавить следующую задачу."
+        user_data["task"] = None
+        user_data["description"] = None
+        user_data["project_id"] = None
+        user_data["priority"] = None
+        user_data["deadline"] = None
+        save_user_data(user_id, user_data)
     else:
         message = "Ошибка при добавлении задачи. Попробуйте снова."
-
-    user_data["task"] = None
-    user_data["description"] = None
-    user_data["project_id"] = None
-    user_data["priority"] = None
-    user_data["deadline"] = None
-    save_user_data(user_id, user_data)
 
     if query:
         await update.callback_query.edit_message_text(message)

--- a/lang.py
+++ b/lang.py
@@ -24,7 +24,7 @@ texts = {
     "project_choice": ["Choose a project:", "Выберите проект:"],
     "no_priority": ["No priority", "Без приоритета"],
     "deadline_skipped": ["Deadline setting skipped.", "Установка дедлайна пропущена."],
-    "err_deadline_invalid": ["Invalid date format. Please, try again.", "Неправильнй формат даты. Попробуйте снова."],
+    "err_deadline_invalid": ["Invalid date format. Please, try again.", "Неправильный формат даты. Попробуйте снова."],
     "deadline_set": ["Deadline set.", "Дедлайн установлен."],
     "success_task_added": ["Task has been added successfully.\nYou may now continue adding tasks.", "Задача успешно добавлена.\nВы можете продолжить добавление задач."],
     "err_task_added": ["An error occurred while adding the task. Please, try again.", "Ошибка при добавлении задачи. Попробуйте снова."],


### PR DESCRIPTION
## Summary
- correct Russian translation typo
- avoid clearing user task data when adding a task fails

## Testing
- `python -m py_compile func.py main.py update.py lang.py`

------
https://chatgpt.com/codex/tasks/task_e_6879383aadf4832f91d6673259a7cc97